### PR TITLE
Add the Windows 10 May 2020 Update to Windows 10 Aggregates

### DIFF
--- a/sql/telemetry/windows_10_aggregate/view.sql
+++ b/sql/telemetry/windows_10_aggregate/view.sql
@@ -17,7 +17,8 @@ WITH
     WHEN windows_build_number <= 17763 THEN '1809'
     WHEN windows_build_number <= 18362 THEN '1903'
     WHEN windows_build_number <= 18363 THEN '1909'
-    WHEN windows_build_number > 18363 THEN 'Insider'
+    WHEN windows_build_number <= 19041 THEN '2004'
+    WHEN windows_build_number > 19041 THEN 'Insider'
     ELSE NULL
     END AS build_group,
     SPLIT(app_version, ".")[OFFSET(0)] AS ff_build_version,


### PR DESCRIPTION
Microsoft will be rolling out the May 2020 update (version 2004) soon. Update the query to break on the final build number for it, 19041.