### PR TITLE
Add Windows 11 23H2 & 24H2 updates to aggregates

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/windows_10_aggregate/view.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry/windows_10_aggregate/view.sql
@@ -32,7 +32,11 @@ WITH aggregated AS (
         THEN 'Win11 21H2'
       WHEN windows_build_number <= 22621
         THEN 'Win11 22H2'
-      WHEN windows_build_number > 22621
+      WHEN windows_build_number <= 22631
+        THEN 'Win11 23H2'
+      WHEN windows_build_number <= 26100
+        THEN 'Win11 24H2'
+      WHEN windows_build_number > 26100
         THEN 'Win11 Insider'
       ELSE NULL
     END AS build_group,


### PR DESCRIPTION
Per https://en.wikipedia.org/wiki/Windows_11_version_history

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title).
- [ ] If the PR comes from a fork, trigger integration CI tests by running the [Push to upstream workflow](https://github.com/mozilla/bigquery-etl/actions/workflows/push-to-upstream.yml) and provide the `<username>:<branch>` of the fork as parameter. The parameter will also show up
in the logs of the `manual-trigger-required-for-fork` CI task together with more detailed instructions.
- [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
- [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
